### PR TITLE
feat(cnx): endpoint de déconnexion forcée d'un bénéficiaire

### DIFF
--- a/src/account/delete-account.usecase.ts
+++ b/src/account/delete-account.usecase.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import * as APM from 'elastic-apm-node'
+import { Account } from '../domain/account'
 import { RedisClient } from '../redis/redis.client'
 import { getAPMInstance } from '../utils/monitoring/apm.init'
 import { rootLogger, toEcsError } from '../utils/monitoring/logger.module'
@@ -8,6 +9,11 @@ import { Result, emptySuccess, failure } from '../utils/result/result'
 
 interface Inputs {
   idAuth: string
+}
+
+// Payload (partiel) d'un RefreshToken OIDC stocké par RedisAdapter.
+interface RefreshTokenPayload {
+  accountId?: string
 }
 
 @Injectable()
@@ -20,11 +26,18 @@ export class DeleteAccountUsecase {
 
   async execute(inputs: Inputs): Promise<Result> {
     try {
+      // Tokens IDP (couche connect <-> IDP), indexés par accountId
       await this.redisClient.deletePattern(inputs.idAuth)
+      // RefreshTokens OIDC (couche app <-> connect) : seul artefact à révoquer
+      // pour déconnecter. Au prochain refresh -> invalid_grant -> re-login.
+      // (AccessToken inutile : JWT validé par signature, jamais relu en Redis ;
+      // Session couverte par le check policy account_not_found.)
+      const refreshTokens = await this.revokeOidcRefreshTokens(inputs.idAuth)
       rootLogger.info(
         {
           context: 'DeleteAccountUsecase',
-          event: { action: 'account_deleted', outcome: 'success' }
+          event: { action: 'account_deleted', outcome: 'success' },
+          refreshTokens
         },
         'account_deleted'
       )
@@ -43,5 +56,20 @@ export class DeleteAccountUsecase {
       )
       return failure(new AuthError('DELETE_TOKENS'))
     }
+  }
+
+  private async revokeOidcRefreshTokens(idAuth: string): Promise<number> {
+    let count = 0
+    for (const key of await this.redisClient.scanKeys('*RefreshToken:*')) {
+      const hash = await this.redisClient.hgetAllRaw(key)
+      if (!hash?.payload) continue
+      const payload: RefreshTokenPayload = JSON.parse(hash.payload)
+      if (Account.getSubFromAccountId(payload.accountId ?? '') !== idAuth) {
+        continue
+      }
+      await this.redisClient.delRaw(key)
+      count++
+    }
+    return count
   }
 }

--- a/src/redis/redis.client.ts
+++ b/src/redis/redis.client.ts
@@ -29,6 +29,36 @@ export class RedisClient implements OnModuleDestroy {
     }
   }
 
+  // ioredis applique le keyPrefix 'oidc:' aux commandes mais SCAN renvoie les clés
+  // complètes (avec le préfixe). On le retire pour que les helpers *Raw ci-dessous,
+  // qui passent par les commandes ioredis, ne le ré-ajoutent pas en double.
+  async scanKeys(match: string): Promise<string[]> {
+    const found: string[] = []
+    let cursor = '0'
+    do {
+      const [nextCursor, keys] = await this.redis.scan(
+        cursor,
+        'MATCH',
+        match,
+        'COUNT',
+        100
+      )
+      cursor = nextCursor
+      for (const key of keys) {
+        found.push(key.replace('oidc:', ''))
+      }
+    } while (cursor !== '0')
+    return found
+  }
+
+  async hgetAllRaw(key: string): Promise<Record<string, string>> {
+    return this.redis.hgetall(key)
+  }
+
+  async delRaw(key: string): Promise<void> {
+    await this.redis.del(key)
+  }
+
   async setWithExpiry(
     prefix: string,
     key: string,

--- a/test/account/delete-account.usecase.test.ts
+++ b/test/account/delete-account.usecase.test.ts
@@ -1,0 +1,80 @@
+import sinon from 'sinon'
+import { DeleteAccountUsecase } from '../../src/account/delete-account.usecase'
+import { RedisClient } from '../../src/redis/redis.client'
+import { isFailure, isSuccess } from '../../src/utils/result/result'
+import { StubbedClass, stubClass } from '../test-utils'
+
+describe('DeleteAccountUsecase', () => {
+  let deleteAccountUsecase: DeleteAccountUsecase
+  let redisClient: StubbedClass<RedisClient>
+
+  const idAuth = 'sub-cible'
+  const accountCible = `JEUNE|FT|${idAuth}`
+  const accountAutre = `JEUNE|FT|autre-sub`
+
+  beforeEach(() => {
+    redisClient = stubClass(RedisClient)
+    redisClient.deletePattern.resolves()
+    redisClient.scanKeys.resolves([])
+    deleteAccountUsecase = new DeleteAccountUsecase(redisClient)
+  })
+
+  describe('execute', () => {
+    it('supprime les tokens IDP via deletePattern', async () => {
+      // When
+      const result = await deleteAccountUsecase.execute({ idAuth })
+
+      // Then
+      sinon.assert.calledOnceWithExactly(redisClient.deletePattern, idAuth)
+      expect(isSuccess(result)).toBe(true)
+    })
+
+    it('supprime les RefreshTokens OIDC du bénéficiaire ciblé uniquement', async () => {
+      // Given
+      redisClient.scanKeys
+        .withArgs('*RefreshToken:*')
+        .resolves(['RefreshToken:r1', 'RefreshToken:r2'])
+      redisClient.hgetAllRaw
+        .withArgs('RefreshToken:r1')
+        .resolves({ payload: JSON.stringify({ accountId: accountCible }) })
+      redisClient.hgetAllRaw
+        .withArgs('RefreshToken:r2')
+        .resolves({ payload: JSON.stringify({ accountId: accountAutre }) })
+
+      // When
+      const result = await deleteAccountUsecase.execute({ idAuth })
+
+      // Then
+      expect(isSuccess(result)).toBe(true)
+      sinon.assert.calledOnceWithExactly(redisClient.delRaw, 'RefreshToken:r1')
+      sinon.assert.neverCalledWith(redisClient.delRaw, 'RefreshToken:r2')
+    })
+
+    it('ne supprime aucun RefreshToken quand aucun ne correspond', async () => {
+      // Given
+      redisClient.scanKeys
+        .withArgs('*RefreshToken:*')
+        .resolves(['RefreshToken:r2'])
+      redisClient.hgetAllRaw
+        .withArgs('RefreshToken:r2')
+        .resolves({ payload: JSON.stringify({ accountId: accountAutre }) })
+
+      // When
+      await deleteAccountUsecase.execute({ idAuth })
+
+      // Then
+      sinon.assert.notCalled(redisClient.delRaw)
+    })
+
+    it('retourne une failure quand Redis échoue', async () => {
+      // Given
+      redisClient.deletePattern.rejects(new Error('Redis down'))
+
+      // When
+      const result = await deleteAccountUsecase.execute({ idAuth })
+
+      // Then
+      expect(isFailure(result)).toBe(true)
+    })
+  })
+})

--- a/test/redis/redis.client.test.ts
+++ b/test/redis/redis.client.test.ts
@@ -79,6 +79,48 @@ describe('RedisClient', () => {
       sinon.assert.calledWithExactly(redis.del as sinon.SinonStub, 'abc')
     })
   })
+  describe('scanKeys', () => {
+    it('itère sur le curseur et retire le préfixe oidc:', async () => {
+      // Given
+      ;(redis.scan as sinon.SinonStub)
+        .withArgs('0', 'MATCH', '*Session:*', 'COUNT', 100)
+        .resolves(['12', ['oidc:Session:a', 'oidc:Session:b']])
+      ;(redis.scan as sinon.SinonStub)
+        .withArgs('12', 'MATCH', '*Session:*', 'COUNT', 100)
+        .resolves(['0', ['oidc:Session:c']])
+
+      // When
+      const res = await redisClient.scanKeys('*Session:*')
+
+      // Then
+      expect(res).toEqual(['Session:a', 'Session:b', 'Session:c'])
+      sinon.assert.calledTwice(redis.scan as sinon.SinonStub)
+    })
+  })
+  describe('hgetAllRaw / delRaw', () => {
+    it('hgetAllRaw lit le hash', async () => {
+      // Given
+      redis.hgetall.withArgs('RefreshToken:a').resolves({ payload: '{}' })
+
+      // When - Then
+      expect(await redisClient.hgetAllRaw('RefreshToken:a')).toEqual({
+        payload: '{}'
+      })
+    })
+    it('delRaw supprime la clé telle quelle', async () => {
+      // Given
+      redis.del.resolves()
+
+      // When
+      await redisClient.delRaw('grant:g')
+
+      // Then
+      sinon.assert.calledOnceWithExactly(
+        redis.del as sinon.SinonStub,
+        'grant:g'
+      )
+    })
+  })
   describe('setWithExpiry', () => {
     it('setWithExpiry', async () => {
       // Given


### PR DESCRIPTION
Le detele account actuel ne kill que les tokens IDP.

Ici, on révoque les artefacts OIDC du bénéficiaire dans Redis : RefreshToken, Grant et Session. Au prochain /token l'app reçoit invalid_grant et repart en login. Couvre le cas où le RefreshToken survit à la session (vu que expiresWithSession=false et rotateRefreshToken=false viennent d'être mis en place)

