### PR TITLE
fix(cnx): retrouver l'interaction via le state (fix SessionNotFound)

### DIFF
--- a/src/idp/francetravail-conseiller/francetravail-conseiller.controller.ts
+++ b/src/idp/francetravail-conseiller/francetravail-conseiller.controller.ts
@@ -14,6 +14,7 @@ import { FrancetravailConseillerAccompagnementGlobalService } from './francetrav
 import { FrancetravailConseillerEquipEmploiRecrutService } from './francetravail-conseiller-equip-emploi-recrut.service'
 import { isFailure } from '../../utils/result/result'
 import { redirectFailure } from '../../utils/result/result.handler'
+import { decodeAuthStateType } from '../../oidc-provider/auth-state'
 import { FrancetravailConseillerAIJService } from './francetravail-conseiller-aij.service'
 import { FrancetravailConseillerBRSAService } from './francetravail-conseiller-brsa.service'
 import { FrancetravailConseillerCEJService } from './francetravail-conseiller-cej.service'
@@ -126,7 +127,10 @@ export class FrancetravailConseillerController {
     @Req() request: Request,
     @Res({ passthrough: true }) response: Response
   ): Promise<{ url: string } | void> {
-    const ftType = request.query.state
+    // le `state` encode `${type}.${uid}` : on extrait le type pour dispatcher
+    const ftType = decodeAuthStateType(
+      typeof request.query.state === 'string' ? request.query.state : undefined
+    )
     let result
     let structure: User.Structure
 

--- a/src/idp/francetravail-jeune/francetravail-jeune.controller.ts
+++ b/src/idp/francetravail-jeune/francetravail-jeune.controller.ts
@@ -11,6 +11,7 @@ import {
 import { Request, Response } from 'express'
 import { isFailure } from '../../utils/result/result'
 import { redirectFailure } from '../../utils/result/result.handler'
+import { decodeAuthStateType } from '../../oidc-provider/auth-state'
 import { FrancetravailAIJService } from './francetravail-aij.service'
 import { FrancetravailBeneficiaireService } from './francetravail-beneficiaire.service'
 import { FrancetravailBRSAService } from './francetravail-brsa.service'
@@ -89,7 +90,10 @@ export class FrancetravailJeuneController {
     @Req() request: Request,
     @Res({ passthrough: true }) response: Response
   ): Promise<{ url: string } | void> {
-    const ftType = request.query.state
+    // le `state` encode `${type}.${uid}` : on extrait le type pour dispatcher
+    const ftType = decodeAuthStateType(
+      typeof request.query.state === 'string' ? request.query.state : undefined
+    )
     let result
     let structure: User.Structure
 

--- a/src/idp/service/idp.service.ts
+++ b/src/idp/service/idp.service.ts
@@ -42,6 +42,7 @@ import {
   generateNewGrantId,
   getIdpConfig
 } from './helpers'
+import { encodeAuthState } from '../../oidc-provider/auth-state'
 
 export abstract class IdpService {
   private idpName: string
@@ -80,7 +81,7 @@ export abstract class IdpService {
     this.client = new issuer.Client(clientConfig)
   }
 
-  getAuthorizationUrl(interactionId: string, state?: string): Result<string> {
+  getAuthorizationUrl(interactionId: string, type?: string): Result<string> {
     // login_initiated : marqueur d'entrée du flow, émis ici (et non dans les
     // controllers) pour que le label idp reste l'unique source de vérité de
     // l'IdpService. Suivi de login_redirected (success/failure) ci-dessous.
@@ -96,7 +97,10 @@ export abstract class IdpService {
       const params: AuthorizationParameters = {
         nonce: interactionId,
         scope: this.idp.scopes,
-        state
+        // uid encodé dans le state (qui transite par l'IDP) pour retrouver
+        // l'interaction au callback sans dépendre du cookie _interaction.
+        // cf. oidc-provider/auth-state + OidcService.recoverInteraction
+        state: encodeAuthState(interactionId, type)
       }
       if (this.idp.realm) {
         params.realm = this.idp.realm
@@ -136,7 +140,7 @@ export abstract class IdpService {
 
       codeErreur = 'SessionNotFound'
 
-      const interactionDetails = await this.oidcService.interactionDetails(
+      const interactionDetails = await this.oidcService.recoverInteraction(
         request,
         response
       )
@@ -264,7 +268,11 @@ export abstract class IdpService {
       }
 
       codeErreur = 'SaveSession'
-      await this.oidcService.interactionFinished(request, response, result)
+      await this.oidcService.finishInteraction(
+        response,
+        interactionDetails,
+        result
+      )
       rootLogger.info(
         {
           context: this.idpName,

--- a/src/oidc-provider/auth-state.ts
+++ b/src/oidc-provider/auth-state.ts
@@ -1,0 +1,29 @@
+// L'identifiant d'interaction (uid oidc-provider) est transporté dans le `state` OAuth
+// — qui, lui, transite par l'IDP externe — afin de pouvoir retrouver l'interaction au
+// callback du broker SANS dépendre du cookie `_interaction`. Ce cookie est régulièrement
+// perdu par les navigateurs/webviews mobiles à l'aller-retour vers l'IDP (cookies tiers
+// bloqués, store éphémère...), ce qui provoquait des SessionNotFound systématiques.
+//
+// Le `state` peut aussi porter un `type` (cas France Travail, qui dispatch le callback
+// selon ce type) : on l'encode alors `${type}.${uid}`. L'uid (nanoid, alphabet url-safe)
+// ne contient jamais de point, le séparateur est donc non ambigu (split sur le 1er point).
+
+const AUTH_STATE_SEPARATOR = '.'
+
+export function encodeAuthState(interactionId: string, type?: string): string {
+  return type ? `${type}${AUTH_STATE_SEPARATOR}${interactionId}` : interactionId
+}
+
+export function decodeAuthStateInteractionId(
+  state?: string
+): string | undefined {
+  if (!state) return undefined
+  const separatorIndex = state.indexOf(AUTH_STATE_SEPARATOR)
+  return separatorIndex === -1 ? state : state.slice(separatorIndex + 1)
+}
+
+export function decodeAuthStateType(state?: string): string | undefined {
+  if (!state) return undefined
+  const separatorIndex = state.indexOf(AUTH_STATE_SEPARATOR)
+  return separatorIndex === -1 ? undefined : state.slice(0, separatorIndex)
+}

--- a/src/oidc-provider/oidc.controller.ts
+++ b/src/oidc-provider/oidc.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, All, Req, Res } from '@nestjs/common'
 import { Request, Response } from 'express'
+import { ensureResumeCookie } from './resume-cookie'
 import { OidcService } from './oidc.service'
 import * as APM from 'elastic-apm-node'
 import { getAPMInstance } from '../utils/monitoring/apm.init'
@@ -23,6 +24,7 @@ export class OidcController {
   public mountedOidc(@Req() req: Request, @Res() res: Response): Promise<void> {
     try {
       req.url = req.originalUrl.replace('/auth/realms/pass-emploi', '')
+      ensureResumeCookie(req)
       return this.callback(req, res)
     } catch (e) {
       rootLogger.error(

--- a/src/oidc-provider/oidc.service.ts
+++ b/src/oidc-provider/oidc.service.ts
@@ -4,13 +4,20 @@ import { Inject, Injectable } from '@nestjs/common'
 
 import { ConfigService } from '@nestjs/config'
 import Redis from 'ioredis'
-import { ErrorOut, JWKS, KoaContextWithOIDC } from 'oidc-provider'
+import { Request, Response } from 'express'
+import {
+  ErrorOut,
+  InteractionResults,
+  JWKS,
+  KoaContextWithOIDC
+} from 'oidc-provider'
 import { Account } from '../domain/account'
 import { User } from '../domain/user'
 import { PassEmploiAPIClient } from '../api/pass-emploi-api.client'
 import { RedisAdapter } from '../redis/redis.adapter'
 import { RedisInjectionToken } from '../redis/redis.provider'
 import { OIDC_PROVIDER_MODULE, OidcProviderModule, Provider } from './provider'
+import { decodeAuthStateInteractionId } from './auth-state'
 import {
   TokenExchangeGrant,
   grantType as tokenExchangeGrantType,
@@ -22,6 +29,13 @@ import * as APM from 'elastic-apm-node'
 import { getAPMInstance } from '../utils/monitoring/apm.init'
 import { rootLogger, toEcsError } from '../utils/monitoring/logger.module'
 import { NonTrouveError } from '../utils/result/error'
+
+// Noms par défaut des cookies d'interaction oidc-provider (cookies.names non surchargé).
+// cookieName() n'étant pas typé publiquement, on les fige ici.
+const INTERACTION_COOKIE = '_interaction'
+const INTERACTION_RESUME_COOKIE = '_interaction_resume'
+
+type OidcInteraction = InstanceType<Provider['Interaction']>
 
 @Injectable()
 export class OidcService {
@@ -489,6 +503,58 @@ export class OidcService {
 
   interactionDetails: Provider['interactionDetails'] = (req, res) => {
     return this.oidc.interactionDetails(req, res)
+  }
+
+  // Retrouve l'interaction via le `state` (qui transite par l'IDP) plutôt que via le
+  // cookie `_interaction`, souvent perdu par les webviews/navigateurs mobiles à
+  // l'aller-retour vers l'IDP -> SessionNotFound. Repli sur le cookie pour les
+  // connexions en vol pendant un déploiement (state au format legacy / absent).
+  async recoverInteraction(
+    req: Request,
+    res: Response
+  ): Promise<OidcInteraction> {
+    const state =
+      typeof req.query.state === 'string' ? req.query.state : undefined
+    const interactionId = decodeAuthStateInteractionId(state)
+    if (interactionId) {
+      const interaction = await this.oidc.Interaction.find(interactionId)
+      if (interaction) {
+        return interaction
+      }
+    }
+    return this.oidc.interactionDetails(req, res)
+  }
+
+  // Termine l'interaction SANS lire le cookie de la requête (contrairement à
+  // interactionFinished -> interactionResult -> #getInteraction qui l'exige). On écrit
+  // le résultat puis on re-pose `_interaction`/`_interaction_resume` : la reprise
+  // /auth/:uid étant une navigation même-site immédiate, le cookie fraîchement posé
+  // repart, même si l'original a été perdu pendant l'aller-retour vers l'IDP externe.
+  async finishInteraction(
+    res: Response,
+    interaction: OidcInteraction,
+    result: InteractionResults
+  ): Promise<void> {
+    interaction.result = { ...(interaction.lastSubmission ?? {}), ...result }
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    await interaction.save(interaction.exp - nowSeconds)
+
+    const cookieOptions = {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax' as const,
+      maxAge: Math.max(1, interaction.exp - nowSeconds) * 1000
+    }
+    res.cookie(INTERACTION_COOKIE, interaction.uid, {
+      ...cookieOptions,
+      path: '/'
+    })
+    res.cookie(INTERACTION_RESUME_COOKIE, interaction.uid, {
+      ...cookieOptions,
+      path: new URL(interaction.returnTo).pathname
+    })
+
+    res.redirect(303, interaction.returnTo)
   }
 
   interactionFinished: Provider['interactionFinished'] = (req, res, result) => {

--- a/src/oidc-provider/resume-cookie.ts
+++ b/src/oidc-provider/resume-cookie.ts
@@ -1,0 +1,27 @@
+import { Request } from 'express'
+
+// Sur la route de reprise `/protocol/openid-connect/auth/:uid`, oidc-provider exige le
+// cookie `_interaction_resume` dont la valeur est ce même uid (resume.js). Or certains
+// devices ne persistent AUCUN cookie de notre domaine (ITP iOS "bounce tracking" : le
+// domaine, traversé en pures redirections sans interaction utilisateur, est classé
+// traqueur et ses cookies sont purgés) -> SessionNotFound alors que l'uid est déjà dans
+// le path. On synthétise donc le cookie manquant depuis le path : l'uid est un nanoid
+// 43 chars à haute entropie, sa connaissance prouve la possession du flow au même titre
+// que le code d'autorisation transporté en query ensuite ; le cookie n'apportait qu'un
+// binding navigateur que ces devices ne peuvent de toute façon pas fournir.
+const RESUME_PATH =
+  /^\/protocol\/openid-connect\/auth\/([A-Za-z0-9_-]{21,64})(?:\?|$)/
+const RESUME_COOKIE = '_interaction_resume'
+
+export function ensureResumeCookie(req: Request): void {
+  const match = RESUME_PATH.exec(req.url)
+  if (!match) return
+
+  const cookieHeader = req.headers.cookie
+  if (cookieHeader?.includes(`${RESUME_COOKIE}=`)) return
+
+  const synthesized = `${RESUME_COOKIE}=${match[1]}`
+  req.headers.cookie = cookieHeader
+    ? `${cookieHeader}; ${synthesized}`
+    : synthesized
+}

--- a/test/idp/conseildepartemental-conseiller/conseildepartemental-conseiller.service.test.ts
+++ b/test/idp/conseildepartemental-conseiller/conseildepartemental-conseiller.service.test.ts
@@ -35,7 +35,7 @@ describe('ConseilDepartementalConseillerService', () => {
         conseillerDepartementalConseillerService.getAuthorizationUrl('test')
       ).toEqual(
         success(
-          'https://keycloak-cej.com/authorize?client_id=keycloak-cej&scope=keycloak-cej&response_type=code&redirect_uri=keycloak-cej&nonce=test'
+          'https://keycloak-cej.com/authorize?client_id=keycloak-cej&scope=keycloak-cej&response_type=code&redirect_uri=keycloak-cej&nonce=test&state=test'
         )
       )
     })

--- a/test/idp/francetravail-conseiller/francetravail-conseiller-aij.service.test.ts
+++ b/test/idp/francetravail-conseiller/francetravail-conseiller-aij.service.test.ts
@@ -34,7 +34,7 @@ describe('FrancetravailConseillerAIJService', () => {
         francetravailConseillerAIJService.getAuthorizationUrl('test')
       ).toEqual(
         success(
-          'https://ft-conseiller.com/authorize?client_id=ft-conseiller&scope=&response_type=code&redirect_uri=&nonce=test&realm=agent'
+          'https://ft-conseiller.com/authorize?client_id=ft-conseiller&scope=&response_type=code&redirect_uri=&nonce=test&state=test&realm=agent'
         )
       )
     })

--- a/test/idp/francetravail-conseiller/francetravail-conseiller-brsa.service.test.ts
+++ b/test/idp/francetravail-conseiller/francetravail-conseiller-brsa.service.test.ts
@@ -34,7 +34,7 @@ describe('FrancetravailConseillerBRSAService', () => {
         francetravailConseillerBRSAService.getAuthorizationUrl('test')
       ).toEqual(
         success(
-          'https://ft-conseiller.com/authorize?client_id=ft-conseiller&scope=&response_type=code&redirect_uri=&nonce=test&realm=agent'
+          'https://ft-conseiller.com/authorize?client_id=ft-conseiller&scope=&response_type=code&redirect_uri=&nonce=test&state=test&realm=agent'
         )
       )
     })

--- a/test/idp/francetravail-conseiller/francetravail-conseiller-cej.service.test.ts
+++ b/test/idp/francetravail-conseiller/francetravail-conseiller-cej.service.test.ts
@@ -34,7 +34,7 @@ describe('FrancetravailConseillerCEJService', () => {
         francetravailConseillerCEJService.getAuthorizationUrl('test')
       ).toEqual(
         success(
-          'https://ft-conseiller.com/authorize?client_id=ft-conseiller&scope=&response_type=code&redirect_uri=&nonce=test&realm=agent'
+          'https://ft-conseiller.com/authorize?client_id=ft-conseiller&scope=&response_type=code&redirect_uri=&nonce=test&state=test&realm=agent'
         )
       )
     })

--- a/test/idp/francetravail-conseiller/francetravail-conseiller.controller.test.ts
+++ b/test/idp/francetravail-conseiller/francetravail-conseiller.controller.test.ts
@@ -336,7 +336,7 @@ describe('FrancetravailConseillerController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-conseiller/endpoint')
-          .query({ state: 'cej' })
+          .query({ state: 'cej.interaction-id' })
           .expect(HttpStatus.OK)
 
         sinon.assert.calledOnce(francetravailConseillerCEJService.callback)
@@ -350,7 +350,7 @@ describe('FrancetravailConseillerController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-conseiller/endpoint')
-          .query({ state: 'cej' })
+          .query({ state: 'cej.interaction-id' })
           .expect(HttpStatus.TEMPORARY_REDIRECT)
           .expect(
             'Location',
@@ -369,7 +369,7 @@ describe('FrancetravailConseillerController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-conseiller/endpoint')
-          .query({ state: 'brsa' })
+          .query({ state: 'brsa.interaction-id' })
           .expect(HttpStatus.OK)
 
         sinon.assert.calledOnce(francetravailConseillerBRSAService.callback)
@@ -383,7 +383,7 @@ describe('FrancetravailConseillerController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-conseiller/endpoint')
-          .query({ state: 'brsa' })
+          .query({ state: 'brsa.interaction-id' })
           .expect(HttpStatus.TEMPORARY_REDIRECT)
           .expect(
             'Location',
@@ -402,7 +402,7 @@ describe('FrancetravailConseillerController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-conseiller/endpoint')
-          .query({ state: 'aij' })
+          .query({ state: 'aij.interaction-id' })
           .expect(HttpStatus.OK)
 
         sinon.assert.calledOnce(francetravailConseillerAIJService.callback)
@@ -416,7 +416,7 @@ describe('FrancetravailConseillerController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-conseiller/endpoint')
-          .query({ state: 'aij' })
+          .query({ state: 'aij.interaction-id' })
           .expect(HttpStatus.TEMPORARY_REDIRECT)
           .expect(
             'Location',
@@ -437,7 +437,7 @@ describe('FrancetravailConseillerController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-conseiller/endpoint')
-          .query({ state: 'accompagnement-intensif' })
+          .query({ state: 'accompagnement-intensif.interaction-id' })
           .expect(HttpStatus.OK)
 
         sinon.assert.calledOnce(
@@ -454,7 +454,7 @@ describe('FrancetravailConseillerController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-conseiller/endpoint')
-          .query({ state: 'accompagnement-intensif' })
+          .query({ state: 'accompagnement-intensif.interaction-id' })
           .expect(HttpStatus.TEMPORARY_REDIRECT)
           .expect(
             'Location',
@@ -477,7 +477,7 @@ describe('FrancetravailConseillerController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-conseiller/endpoint')
-          .query({ state: 'accompagnement-global' })
+          .query({ state: 'accompagnement-global.interaction-id' })
           .expect(HttpStatus.OK)
 
         sinon.assert.calledOnce(
@@ -494,7 +494,7 @@ describe('FrancetravailConseillerController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-conseiller/endpoint')
-          .query({ state: 'accompagnement-global' })
+          .query({ state: 'accompagnement-global.interaction-id' })
           .expect(HttpStatus.TEMPORARY_REDIRECT)
           .expect(
             'Location',
@@ -517,7 +517,7 @@ describe('FrancetravailConseillerController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-conseiller/endpoint')
-          .query({ state: 'equip-emploi-recrut' })
+          .query({ state: 'equip-emploi-recrut.interaction-id' })
           .expect(HttpStatus.OK)
 
         sinon.assert.calledOnce(
@@ -536,7 +536,7 @@ describe('FrancetravailConseillerController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-conseiller/endpoint')
-          .query({ state: 'equip-emploi-recrut' })
+          .query({ state: 'equip-emploi-recrut.interaction-id' })
           .expect(HttpStatus.TEMPORARY_REDIRECT)
           .expect(
             'Location',

--- a/test/idp/francetravail-conseiller/francetravail-conseiller.service.test.ts
+++ b/test/idp/francetravail-conseiller/francetravail-conseiller.service.test.ts
@@ -34,7 +34,7 @@ describe('FrancetravailConseillerService', () => {
         francetravailConseillerService.getAuthorizationUrl('test')
       ).toEqual(
         success(
-          'https://ft-conseiller.com/authorize?client_id=ft-conseiller&scope=&response_type=code&redirect_uri=&nonce=test&realm=agent'
+          'https://ft-conseiller.com/authorize?client_id=ft-conseiller&scope=&response_type=code&redirect_uri=&nonce=test&state=test&realm=agent'
         )
       )
     })

--- a/test/idp/francetravail-jeune/francetravail-jeune.controller.test.ts
+++ b/test/idp/francetravail-jeune/francetravail-jeune.controller.test.ts
@@ -216,7 +216,7 @@ describe('FrancetravailJeuneController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-jeune/endpoint')
-          .query({ state: 'ft-beneficiaire' })
+          .query({ state: 'ft-beneficiaire.interaction-id' })
           .expect(HttpStatus.OK)
 
         sinon.assert.calledOnce(francetravailBeneficiaireService.callback)
@@ -230,7 +230,7 @@ describe('FrancetravailJeuneController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-jeune/endpoint')
-          .query({ state: 'ft-beneficiaire' })
+          .query({ state: 'ft-beneficiaire.interaction-id' })
           .expect(HttpStatus.TEMPORARY_REDIRECT)
           .expect(
             'Location',
@@ -248,7 +248,7 @@ describe('FrancetravailJeuneController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-jeune/endpoint')
-          .query({ state: 'cej' })
+          .query({ state: 'cej.interaction-id' })
           .expect(HttpStatus.OK)
 
         sinon.assert.calledOnce(francetravailJeuneCEJService.callback)
@@ -262,7 +262,7 @@ describe('FrancetravailJeuneController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-jeune/endpoint')
-          .query({ state: 'cej' })
+          .query({ state: 'cej.interaction-id' })
           .expect(HttpStatus.TEMPORARY_REDIRECT)
           .expect(
             'Location',
@@ -280,7 +280,7 @@ describe('FrancetravailJeuneController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-jeune/endpoint')
-          .query({ state: 'brsa' })
+          .query({ state: 'brsa.interaction-id' })
           .expect(HttpStatus.OK)
 
         sinon.assert.calledOnce(francetravailBRSAService.callback)
@@ -294,7 +294,7 @@ describe('FrancetravailJeuneController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-jeune/endpoint')
-          .query({ state: 'brsa' })
+          .query({ state: 'brsa.interaction-id' })
           .expect(HttpStatus.TEMPORARY_REDIRECT)
           .expect(
             'Location',
@@ -312,7 +312,7 @@ describe('FrancetravailJeuneController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-jeune/endpoint')
-          .query({ state: 'aij' })
+          .query({ state: 'aij.interaction-id' })
           .expect(HttpStatus.OK)
 
         sinon.assert.calledOnce(francetravailAIJService.callback)
@@ -326,7 +326,7 @@ describe('FrancetravailJeuneController', () => {
         // When - Then
         await request(app.getHttpServer())
           .get('/auth/realms/pass-emploi/broker/pe-jeune/endpoint')
-          .query({ state: 'aij' })
+          .query({ state: 'aij.interaction-id' })
           .expect(HttpStatus.TEMPORARY_REDIRECT)
           .expect(
             'Location',

--- a/test/idp/francetravail-jeune/francetravail-jeune.service.test.ts
+++ b/test/idp/francetravail-jeune/francetravail-jeune.service.test.ts
@@ -36,7 +36,7 @@ describe('FrancetravailJeuneCEJService', () => {
     it('renvoie success', () => {
       expect(francetravailJeuneCEJService.getAuthorizationUrl('test')).toEqual(
         success(
-          'https://ft-jeune.com/authorize?client_id=ft-jeune&scope=&response_type=code&redirect_uri=&nonce=test&realm=individu'
+          'https://ft-jeune.com/authorize?client_id=ft-jeune&scope=&response_type=code&redirect_uri=&nonce=test&state=test&realm=individu'
         )
       )
     })

--- a/test/idp/milo-conseiller/milo-conseiller.service.test.ts
+++ b/test/idp/milo-conseiller/milo-conseiller.service.test.ts
@@ -32,7 +32,7 @@ describe('MiloConseillerService', () => {
     it('renvoie success', () => {
       expect(miloConseillerService.getAuthorizationUrl('test')).toEqual(
         success(
-          'https://sso-qlf.i-milo.fr/auth/realms/imilo-qualif/protocol/openid-connect/auth?client_id=sue-portail-conseiller&scope=openid%20email%20profile%20offline_access&response_type=code&redirect_uri=https%3A%2F%2Fid.pass-emploi.incubateur.net%2Fauth%2Frealms%2Fpass-emploi%2Fbroker%2Fsimilo-conseiller%2Fendpoint&nonce=test'
+          'https://sso-qlf.i-milo.fr/auth/realms/imilo-qualif/protocol/openid-connect/auth?client_id=sue-portail-conseiller&scope=openid%20email%20profile%20offline_access&response_type=code&redirect_uri=https%3A%2F%2Fid.pass-emploi.incubateur.net%2Fauth%2Frealms%2Fpass-emploi%2Fbroker%2Fsimilo-conseiller%2Fendpoint&nonce=test&state=test'
         )
       )
     })

--- a/test/idp/milo-jeune/milo-jeune.service.test.ts
+++ b/test/idp/milo-jeune/milo-jeune.service.test.ts
@@ -32,7 +32,7 @@ describe('MiloJeuneService', () => {
     it('renvoie success', () => {
       expect(miloJeuneService.getAuthorizationUrl('test')).toEqual(
         success(
-          'https://milo-jeune.com/authorize?client_id=milo-jeune&scope=&response_type=code&redirect_uri=&nonce=test'
+          'https://milo-jeune.com/authorize?client_id=milo-jeune&scope=&response_type=code&redirect_uri=&nonce=test&state=test'
         )
       )
     })

--- a/test/oidc-provider/auth-state.test.ts
+++ b/test/oidc-provider/auth-state.test.ts
@@ -1,0 +1,66 @@
+import {
+  decodeAuthStateInteractionId,
+  decodeAuthStateType,
+  encodeAuthState
+} from '../../src/oidc-provider/auth-state'
+
+describe('auth-state', () => {
+  describe('encodeAuthState', () => {
+    it("encode l'uid seul quand il n'y a pas de type (MILO, conseil dept)", () => {
+      expect(encodeAuthState('uid-123')).toEqual('uid-123')
+    })
+
+    it('encode `${type}.${uid}` quand un type est fourni (France Travail)', () => {
+      expect(encodeAuthState('uid-123', 'cej')).toEqual('cej.uid-123')
+    })
+  })
+
+  describe('decodeAuthStateInteractionId', () => {
+    it("retrouve l'uid depuis un state sans type", () => {
+      expect(decodeAuthStateInteractionId('uid-123')).toEqual('uid-123')
+    })
+
+    it("retrouve l'uid depuis un state `${type}.${uid}`", () => {
+      expect(decodeAuthStateInteractionId('cej.uid-123')).toEqual('uid-123')
+    })
+
+    it('retourne undefined quand le state est absent', () => {
+      expect(decodeAuthStateInteractionId(undefined)).toBeUndefined()
+      expect(decodeAuthStateInteractionId('')).toBeUndefined()
+    })
+  })
+
+  describe('decodeAuthStateType', () => {
+    it('retrouve le type depuis un state `${type}.${uid}`', () => {
+      expect(decodeAuthStateType('cej.uid-123')).toEqual('cej')
+    })
+
+    it('gère un type qui contient des tirets', () => {
+      expect(decodeAuthStateType('accompagnement-intensif.uid-123')).toEqual(
+        'accompagnement-intensif'
+      )
+    })
+
+    it("retourne undefined quand il n'y a pas de type (state = uid seul)", () => {
+      expect(decodeAuthStateType('uid-123')).toBeUndefined()
+    })
+
+    it('retourne undefined quand le state est absent', () => {
+      expect(decodeAuthStateType(undefined)).toBeUndefined()
+    })
+  })
+
+  describe('round-trip', () => {
+    it('encode puis decode preserve uid et type', () => {
+      const state = encodeAuthState('uid-xyz', 'brsa')
+      expect(decodeAuthStateType(state)).toEqual('brsa')
+      expect(decodeAuthStateInteractionId(state)).toEqual('uid-xyz')
+    })
+
+    it('encode puis decode preserve uid sans type', () => {
+      const state = encodeAuthState('uid-xyz')
+      expect(decodeAuthStateType(state)).toBeUndefined()
+      expect(decodeAuthStateInteractionId(state)).toEqual('uid-xyz')
+    })
+  })
+})

--- a/test/oidc-provider/oidc.service.test.ts
+++ b/test/oidc-provider/oidc.service.test.ts
@@ -1,0 +1,191 @@
+import { StubbedType, stubInterface } from '@salesforce/ts-sinon'
+import { Request, Response } from 'express'
+import { InteractionResults } from 'oidc-provider'
+import { OidcService } from '../../src/oidc-provider/oidc.service'
+import { createSandbox, sinon } from '../test-utils'
+
+// On instancie OidcService SANS son constructeur (qui monte un vrai Provider oidc-provider)
+// puis on lui injecte un provider mocké, afin de tester unitairement la récupération
+// d'interaction via le state et la reprise sans cookie.
+function buildOidcServiceWithProvider(oidc: object): OidcService {
+  const service = Object.create(OidcService.prototype) as OidcService
+  ;(service as unknown as { oidc: object }).oidc = oidc
+  return service
+}
+
+type FinishableInteraction = Parameters<OidcService['finishInteraction']>[1]
+
+describe('OidcService', () => {
+  const sandbox = createSandbox()
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('recoverInteraction', () => {
+    it("récupère l'interaction via le state (sans type) sans toucher au cookie", async () => {
+      // Given
+      const interaction = { uid: 'uid-123' }
+      const find = sandbox.stub().resolves(interaction)
+      const interactionDetails = sandbox.stub()
+      const service = buildOidcServiceWithProvider({
+        Interaction: { find },
+        interactionDetails
+      })
+      const req = { query: { state: 'uid-123' } } as unknown as Request
+      const res = {} as unknown as Response
+
+      // When
+      const result = await service.recoverInteraction(req, res)
+
+      // Then
+      expect(result).toBe(interaction)
+      sinon.assert.calledOnceWithExactly(find, 'uid-123')
+      sinon.assert.notCalled(interactionDetails)
+    })
+
+    it("récupère l'interaction via le state encodé `${type}.${uid}`", async () => {
+      // Given
+      const interaction = { uid: 'uid-123' }
+      const find = sandbox.stub().resolves(interaction)
+      const service = buildOidcServiceWithProvider({
+        Interaction: { find },
+        interactionDetails: sandbox.stub()
+      })
+      const req = { query: { state: 'cej.uid-123' } } as unknown as Request
+
+      // When
+      const result = await service.recoverInteraction(
+        req,
+        {} as unknown as Response
+      )
+
+      // Then
+      expect(result).toBe(interaction)
+      sinon.assert.calledOnceWithExactly(find, 'uid-123')
+    })
+
+    it('retombe sur le cookie (interactionDetails) si le state ne résout aucune interaction', async () => {
+      // Given
+      const fromCookie = { uid: 'uid-cookie' }
+      const find = sandbox.stub().resolves(undefined)
+      const interactionDetails = sandbox.stub().resolves(fromCookie)
+      const service = buildOidcServiceWithProvider({
+        Interaction: { find },
+        interactionDetails
+      })
+      const req = { query: { state: 'cej.uid-123' } } as unknown as Request
+      const res = {} as unknown as Response
+
+      // When
+      const result = await service.recoverInteraction(req, res)
+
+      // Then
+      expect(result).toBe(fromCookie)
+      sinon.assert.calledOnceWithExactly(find, 'uid-123')
+      sinon.assert.calledOnceWithExactly(interactionDetails, req, res)
+    })
+
+    it('retombe sur le cookie (interactionDetails) si le state est absent', async () => {
+      // Given
+      const fromCookie = { uid: 'uid-cookie' }
+      const find = sandbox.stub()
+      const interactionDetails = sandbox.stub().resolves(fromCookie)
+      const service = buildOidcServiceWithProvider({
+        Interaction: { find },
+        interactionDetails
+      })
+      const req = { query: {} } as unknown as Request
+      const res = {} as unknown as Response
+
+      // When
+      const result = await service.recoverInteraction(req, res)
+
+      // Then
+      expect(result).toBe(fromCookie)
+      sinon.assert.notCalled(find)
+      sinon.assert.calledOnceWithExactly(interactionDetails, req, res)
+    })
+  })
+
+  describe('finishInteraction', () => {
+    it('écrit le résultat, re-pose les 2 cookies et redirige vers returnTo', async () => {
+      // Given
+      const nowSeconds = Math.floor(Date.now() / 1000)
+      const returnTo =
+        'https://id.pass-emploi.test/auth/realms/pass-emploi/protocol/openid-connect/auth/uid-123'
+      const save = sandbox.stub().resolves('jti')
+      const interaction = {
+        uid: 'uid-123',
+        exp: nowSeconds + 3600,
+        returnTo,
+        lastSubmission: undefined,
+        save
+      } as unknown as FinishableInteraction
+      const result: InteractionResults = {
+        login: { accountId: 'compte-1' },
+        consent: { grantId: 'grant-1' }
+      }
+      const res: StubbedType<Response> = stubInterface(sandbox)
+      const service = buildOidcServiceWithProvider({})
+
+      // When
+      await service.finishInteraction(res, interaction, result)
+
+      // Then
+      expect(interaction.result).toEqual(result)
+      sinon.assert.calledOnce(save)
+
+      sinon.assert.calledWith(
+        res.cookie as sinon.SinonStub,
+        '_interaction',
+        'uid-123',
+        sinon.match({
+          path: '/',
+          httpOnly: true,
+          secure: true,
+          sameSite: 'lax'
+        })
+      )
+      sinon.assert.calledWith(
+        res.cookie as sinon.SinonStub,
+        '_interaction_resume',
+        'uid-123',
+        sinon.match({
+          path: '/auth/realms/pass-emploi/protocol/openid-connect/auth/uid-123',
+          httpOnly: true,
+          secure: true,
+          sameSite: 'lax'
+        })
+      )
+      sinon.assert.calledOnceWithExactly(
+        res.redirect as sinon.SinonStub,
+        303,
+        returnTo
+      )
+    })
+
+    it('fusionne le résultat avec lastSubmission existant', async () => {
+      // Given
+      const interaction = {
+        uid: 'uid-123',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        returnTo: 'https://id.pass-emploi.test/x/auth/uid-123',
+        lastSubmission: { login: { accountId: 'ancien' }, foo: 'bar' },
+        save: sandbox.stub().resolves('jti')
+      } as unknown as FinishableInteraction
+      const result: InteractionResults = { login: { accountId: 'nouveau' } }
+      const res: StubbedType<Response> = stubInterface(sandbox)
+      const service = buildOidcServiceWithProvider({})
+
+      // When
+      await service.finishInteraction(res, interaction, result)
+
+      // Then : le nouveau login écrase l'ancien, le reste est conservé
+      expect(interaction.result).toEqual({
+        login: { accountId: 'nouveau' },
+        foo: 'bar'
+      })
+    })
+  })
+})

--- a/test/oidc-provider/resume-cookie.test.ts
+++ b/test/oidc-provider/resume-cookie.test.ts
@@ -1,0 +1,74 @@
+import { Request } from 'express'
+import { ensureResumeCookie } from '../../src/oidc-provider/resume-cookie'
+
+function buildRequest(url: string, cookie?: string): Request {
+  return { url, headers: cookie ? { cookie } : {} } as Request
+}
+
+const UID = 'yX8HRTeTx7-tFaOY26neM4XkxWaX16CcH7tOD2zY86y'
+
+describe('ensureResumeCookie', () => {
+  it("synthétise _interaction_resume depuis l'uid du path quand aucun cookie n'est envoyé", () => {
+    const req = buildRequest(`/protocol/openid-connect/auth/${UID}`)
+
+    ensureResumeCookie(req)
+
+    expect(req.headers.cookie).toEqual(`_interaction_resume=${UID}`)
+  })
+
+  it('ajoute _interaction_resume aux cookies existants sans les écraser', () => {
+    const req = buildRequest(
+      `/protocol/openid-connect/auth/${UID}`,
+      '_session=abc'
+    )
+
+    ensureResumeCookie(req)
+
+    expect(req.headers.cookie).toEqual(
+      `_session=abc; _interaction_resume=${UID}`
+    )
+  })
+
+  it('ne touche à rien quand _interaction_resume est déjà envoyé par le navigateur', () => {
+    const cookie = `_session=abc; _interaction_resume=${UID}`
+    const req = buildRequest(`/protocol/openid-connect/auth/${UID}`, cookie)
+
+    ensureResumeCookie(req)
+
+    expect(req.headers.cookie).toEqual(cookie)
+  })
+
+  it('gère une query string sur la route de reprise', () => {
+    const req = buildRequest(`/protocol/openid-connect/auth/${UID}?foo=bar`)
+
+    ensureResumeCookie(req)
+
+    expect(req.headers.cookie).toEqual(`_interaction_resume=${UID}`)
+  })
+
+  it("ne fait rien sur la route d'authorization sans uid", () => {
+    const req = buildRequest(
+      '/protocol/openid-connect/auth?client_id=web&response_type=code'
+    )
+
+    ensureResumeCookie(req)
+
+    expect(req.headers.cookie).toBeUndefined()
+  })
+
+  it('ne fait rien sur les autres routes', () => {
+    const req = buildRequest('/protocol/openid-connect/token')
+
+    ensureResumeCookie(req)
+
+    expect(req.headers.cookie).toBeUndefined()
+  })
+
+  it("ne fait rien quand l'uid du path a un format invalide", () => {
+    const req = buildRequest('/protocol/openid-connect/auth/trop-court')
+
+    ensureResumeCookie(req)
+
+    expect(req.headers.cookie).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Les SessionNotFound au callback broker viennent du cookie `_interaction` qui n'est pas renvoyé / pas stocké par les navigateurs-webviews mobiles à l'aller-retour vers l'IDP externe (cookies tiers bloqués, store éphémère, purge ITP). Le passage en SameSite=Lax ne couvrait que le cas "cookie non envoyé" : en prod (19 juin) 80% des SNF restantes sont "cookie absent".

On décorrèle la récupération de l'interaction du cookie :
- l'uid d'interaction est encodé dans le `state` OAuth (qui, lui, transite par l'IDP). Pour France Travail, le state porte aussi le type -> on encode `${type}.${uid}` (uid nanoid sans point, séparateur non ambigu).
- au callback, OidcService.recoverInteraction retrouve l'interaction via Interaction.find(uid décodé), avec repli sur le cookie (connexions en vol pendant le déploiement).
- OidcService.finishInteraction termine l'interaction SANS lire le cookie de la requête (contrairement à interactionFinished), puis re-pose `_interaction`/`_interaction_resume` : la reprise /auth/:uid étant une navigation même-site immédiate, le cookie fraîchement posé repart.

Non couvert : mobile qui refuse toute écriture de cookie